### PR TITLE
Fix Python helper so AMQP python class can use username/password

### DIFF
--- a/src/main/scala/org/apache/spark/streaming/amqp/AMQPUtils.scala
+++ b/src/main/scala/org/apache/spark/streaming/amqp/AMQPUtils.scala
@@ -149,9 +149,11 @@ class AMQPUtilsPythonHelper {
        jssc: JavaStreamingContext,
        host: String,
        port: Int,
+       username: Option[String],
+       password: Option[String],
        address: String
      ): JavaDStream[String] = {
 
-    AMQPUtils.createStream(jssc, host, port, None, None, address)
+    AMQPUtils.createStream(jssc, host, port, username, password, address)
   }
 }

--- a/src/main/scala/org/apache/spark/streaming/amqp/AMQPUtils.scala
+++ b/src/main/scala/org/apache/spark/streaming/amqp/AMQPUtils.scala
@@ -149,11 +149,11 @@ class AMQPUtilsPythonHelper {
        jssc: JavaStreamingContext,
        host: String,
        port: Int,
-       username: Option[String],
-       password: Option[String],
+       username: String,
+       password: String,
        address: String
      ): JavaDStream[String] = {
-
-    AMQPUtils.createStream(jssc, host, port, username, password, address)
+    
+    AMQPUtils.createStream(jssc, host, port, Option(username), Option(password), address)
   }
 }


### PR DESCRIPTION
By making changes in AMQPUtils.scala, the AMQPUtilsPythonHelper class is able to accept username and password values.